### PR TITLE
Fix: Resolve JSON unmarshalling error for `trigger_parameters` in `circleci_pipeline` table, support project_slug format `circleci/<Org ID>/<Project ID>`  Closes #52

### DIFF
--- a/circleci/table_circleci_pipeline.go
+++ b/circleci/table_circleci_pipeline.go
@@ -69,6 +69,14 @@ func listCircleCIPipelines(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	}
 
 	for _, pipeline := range pipelines.Items {
+
+		// For projects that use GitLab or GitHub App, use circleci as the vcs-slug, replace org-name with the organization ID (found in Organization Settings), and replace repo-name with the project ID (found in Project Settings).
+		// If we pass the `project_slug` value as "select * from circleci_pipeline where project_slug = 'circleci/5ad8293d-30b0-4594-be94-0b28fb727eef/b20334e0-c813-4c0f-a27d-9a1ca2488548'",
+		// the API returns the value as "circleci/CDdrPhWsW7Pa5PNcj4Y7en/NywbLpDu1Eb1Pobxj3Nphu".
+		// Due to Steampipe's filtering mechanism, this results in empty rows.
+		// Since "project_slug" is required to query this table, we assign the "project_slug" from the WHERE clause directly.
+		pipeline.ProjectSlug = projectSlug
+		
 		d.StreamListItem(ctx, pipeline)
 
 		// Context can be cancelled due to manual cancellation or the limit has been hit

--- a/rest/resource.go
+++ b/rest/resource.go
@@ -9,12 +9,12 @@ type PipelineResponse struct {
 			Type    string `json:"type"`
 			Message string `json:"message"`
 		} `json:"errors"`
-		ProjectSlug       string            `json:"project_slug"`
-		UpdatedAt         time.Time         `json:"updated_at"`
-		Number            int               `json:"number"`
-		TriggerParameters map[string]string `json:"trigger_parameters"`
-		State             string            `json:"state"`
-		CreatedAt         time.Time         `json:"created_at"`
+		ProjectSlug       string                 `json:"project_slug"`
+		UpdatedAt         time.Time              `json:"updated_at"`
+		Number            int                    `json:"number"`
+		TriggerParameters map[string]interface{} `json:"trigger_parameters"`
+		State             string                 `json:"state"`
+		CreatedAt         time.Time              `json:"created_at"`
 		Trigger           struct {
 			Type       string    `json:"type"`
 			ReceivedAt time.Time `json:"received_at"`


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>

```
> select * from circleci_pipeline where project_slug = 'circleci/5ad8293d-30b0-4594-be94-0b28fb727eef/b20334e0-c813-4c0f-a27d-9a1ca2488548'
+--------------------------------------+------------------------------------------------------------------------------------+--------------------------------------+--------+---------------------------+-------------------------------------------------------------------->
| login_id                             | project_slug                                                                       | id                                   | number | created_at                | errors                                                             >
+--------------------------------------+------------------------------------------------------------------------------------+--------------------------------------+--------+---------------------------+-------------------------------------------------------------------->
| 8af2743c-f61b-4a1e-8571-fb121a01eace | circleci/5ad8293d-30b0-4594-be94-0b28fb727eef/b20334e0-c813-4c0f-a27d-9a1ca2488548 | f4395ca3-1eff-496d-9599-2f260041c50b | 1      | 2024-10-29T13:34:13+05:30 | [{"message":"There are jobs referenced in workflows that have not b>
|                                      |                                                                                    |                                      |        |                           |                                                                    >
+--------------------------------------+------------------------------------------------------------------------------------+--------------------------------------+--------+---------------------------+--------------------------------------------------------------------
```
</details>
